### PR TITLE
Non-CO2 warming effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ these short-term emissions, and reported in units of mW/m<sup>2</sup> (global
 average).
 
 The two largest warming contributors for 2018 are contrail-induced cirrus clouds
-and CO<sub>2</sub> from fuel emissions.
+and CO<sub>2</sub> from fuel emissions. Other important ERF components are NO<sub>x</sub>, sulfur and soot emissions, as well as water vapor emissions.
 
 The TIM calculates CO<sub>2</sub>e emissions based on global warming potentials
 over a 100-year horizon — GWP100, an oft-cited metric used by the Kyoto Protocol

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ example emissions forecast for a B789 aircraft:
    </td>
    <td style="background-color: null"><code>LTO CO<sub>2 </sub>forecast<sub> </sub>(kg)</code>
    </td>
-   <td style="background-color: null"><code>CCD CO<sub>2 
+   <td style="background-color: null"><code>CCD CO<sub>2
 </sub>forecast<sub> </sub>(kg)</code>
    </td>
   </tr>
@@ -191,7 +191,7 @@ Used for flight level emissions:
 Non-CO<sub>2</sub> emissions from aviation are a significant fraction of
 aviation’s net climate effect. As cited by the IPCC’s
 [AR6 report](https://www.ipcc.ch/report/ar6/wg1/#FullReport), Lee et al.
-[[2020](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7468346/)] provides a
+[[2021](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7468346/)] provides a
 comprehensive review of aviation climate emissions, aggregating the results from
 32 published studies.
 
@@ -217,8 +217,8 @@ SLCP emissions can be converted to absolute CO<sub>2</sub>e by calculating the
 CO<sub>2</sub> emission (AGWP100) required to produce the same average radiative
 forcing over a 100 year period. The AGWP100 of CO<sub>2</sub> is roughly
 91mW/m<sup>2</sup> per 1Gt-CO<sub>2</sub>/yr
-[[AR5, Myhre, G. et al](https://www.ipcc.ch/site/assets/uploads/2018/07/WGI_AR5.Chap_.8_SM.pdf)].
-Using numbers from Lee et al (2020) presented in Table 2, the
+[[AR5, Myhre, G. et al.](https://www.ipcc.ch/site/assets/uploads/2018/07/WGI_AR5.Chap_.8_SM.pdf)].
+Using numbers from Lee et al. (2021) presented in Table 2, the
 kg-CO<sub>2</sub>e/km can then be calculated for each non-CO<sub>2</sub> source
 based on ERF, and aviation miles flown:
 
@@ -234,13 +234,13 @@ based on ERF, and aviation miles flown:
 </strong>(mW m−2)<strong> <br/>
 </strong>Median (5th, 95th)
    </td>
-   <td style="background-color: null; text-align: center"><strong>AGWP100 
+   <td style="background-color: null; text-align: center"><strong>AGWP100
 </strong><br/>(metric megatons
-CO2e yr-1)<br/><strong> 
+CO2e yr-1)<br/><strong>
 </strong>Median (5th, 95th)
    </td>
-   <td style="background-color: null; text-align: center"><strong>CO2e per flight km* 
-</strong><br/>(kg-CO2e km-1)<br/><strong> 
+   <td style="background-color: null; text-align: center"><strong>CO2e per flight km*
+</strong><br/>(kg-CO2e km-1)<br/><strong>
 </strong>Median (5th, 95th)
    </td>
   </tr>


### PR DESCRIPTION
Since issues are disabled for this repo, we would like to address here some comments and question regarding the section “From CO2 to CO2e emissions” of the TIM methodology description:

- First of all, the main question is what is the reason for ignoring some of the important aviation related emissions (ERF components): nitrogen oxides (NOx), water vapor, soot and sulfate aerosols in your calculation model? In the paper referenced by you (Lee et al, 2021) they are all clearly listed out along with their CO2 equivalent values for the year 2018.

- It is not very clear from your description how do your arrive at the value of _629 (186, 1075_) for AGWP100 for contrail cirrus. According to the Table 5 of Lee et al, 2021 the value should rather be **652 Tg CO2e per year**? Also, it is unclear from the description how do you get the values for CO2e per flight km.

- You claim non-CO2 effects to contribute an additional 61% on top of the aviation CO2 emissions, however this seems to be quite an understatement. Even though there is a lot of uncertainty around aviation caused RF effects, with the current growing emission trends an overall warming effect of aviation related emissions should be at least **3 times higher** than just the CO2 emissions alone?